### PR TITLE
allowing extra options for amqplib

### DIFF
--- a/lib/sockets.js
+++ b/lib/sockets.js
@@ -159,6 +159,7 @@ function setsockopt(opt, value) {
   case 'persistent':
   case 'topic':
   case 'task':
+  default:
     this.options[opt] = value; break;
   }
 }
@@ -191,7 +192,8 @@ PubSocket.prototype.publish = function(topic, chunk, encoding) {
   var ch = this.ch;
   if (!topic) topic = this.options.topic || '';
   var options = {expiration: this.options.expiration,
-                 persistent: this.options.persistent};
+                 persistent: this.options.persistent,
+                 contentType: this.options.contentType};
   var allpubs = true;
   this.pubs.forEach(function(dest) {
     allpubs = allpubs &&


### PR DESCRIPTION
was trying to use some of the options from amqplib but i found the `setsockopt function` din't allow for extra options, and also the variable options in the function publish was overriding any new option set with setsockopt.

http://www.squaremobius.net/amqp.node/doc/channel_api.html

I'm only adding publish#contentType for now but i can add more later on.